### PR TITLE
Original repo broken service handle missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,102 @@
+# Modern Delphi 12.3 .gitignore
+#
+#-------------------------------------------------------------------------------
+# Delphi / C++Builder Compiled Output & Binaries
+#-------------------------------------------------------------------------------
 *.exe
 *.dll
+*.so
+*.a
+*.lib
+*.bpl
+*.dcp
 *.dcu
-*.bkm
+*.obj
+*.o
+
+# Compiled resource files
+*.res 
+
+#-------------------------------------------------------------------------------
+# IDE Generated, User-Specific & Intermediate Files
+#-------------------------------------------------------------------------------
+*.~*
+*.bak
+*.old
+
+# Delphi 7 and Delphi 6 Diagram Portfolio
+*.ddp
+
+# Delphi 7 (and older) Project Configuration filed automatically created by command line compiler
+*.cfg
+
+# General temporary files
+*.tmp 
+
+# General temporary files
+*.temp 
+
+*.local
+*.dsk
+*.cfg
+*.map
+*.tds
 *.drc
-*.zip
-dcu
+*.rsm
+*.log
+*.pch
+*.ipch
+*.stat
+*.identcache
+*.dproj.local
+*.dproj.user
+*.groupproj.local
+*.groupproj.user
+
+# Delphi IDE bookmarks
+*.bkm 
+
+# TestInsight configuration files
+*.tvsconfig 
+
+# Files with .history extension
+*.history 
+
+# Legacy project files
+*.dof
+*.kof
+
+#-------------------------------------------------------------------------------
+# IDE History, Recovery & Autosave
+#-------------------------------------------------------------------------------
+**/__history/
+**/__recovery/
+*.autosave
+
+#-------------------------------------------------------------------------------
+# Output Directories (using **/ to match at any depth)
+#-------------------------------------------------------------------------------
+**/Win32/
+**/Win64/
+**/Debug/
+**/Release/
+
+# Cross-platform output folders
+**/Linux64/
+**/OSX64/
+**/OSXARM64/
+**/Android/
+**/Android64/
+**/iOSDevice32/
+**/iOSDevice64/
+**/iOSSimulator/
+
+#-------------------------------------------------------------------------------
+# Common Temporary / Local / Sensitive Files (General)
+#-------------------------------------------------------------------------------
+# General compressed archives (often backups or downloads)
+*.zip 
+
+# Environment variable files (CRITICAL for sensitive data)
+*.env 
+

--- a/RamSync.pas
+++ b/RamSync.pas
@@ -295,6 +295,9 @@ Begin
   WideFindClose(SR);
 end;
 
+(*
+
+// old split path
 Procedure SplitPath(const path:WideString;var list:TStrArray);
 var
   oldPos,newPos,k:Integer;
@@ -313,6 +316,83 @@ Begin
     Inc(k);
   Until newPos=0;
   SetLength(list,k);
+end;
+
+*)
+
+// Make sure to place WidePosExChar above SplitPath or in an interface section
+// New WidePosExChar by Gemini 2.5 Pro
+function WidePosExChar(const SearchChar: WideChar; const S: WideString; StartPos: Integer = 1): Integer;
+var
+  I: Integer;
+begin
+  Result := 0; // Not found by default
+  for I := StartPos to Length(S) do
+  begin
+    if S[I] = SearchChar then
+    begin
+      Result := I;
+      Exit;
+    end;
+  end;
+end;
+
+// Assuming TStrArray is defined as array of WideString, e.g.:
+// type
+//   TStrArray = array of WideString;
+
+// new SplitPath by Gemini 2.5 Pro
+Procedure SplitPath(const path:WideString;var list:TStrArray);
+var
+  oldPos, newPos, k: Integer;
+Begin
+  // Initialize list with a reasonable capacity. Length(path) is an overestimate,
+  // but ensures enough initial space. It will be trimmed later.
+  SetLength(List, Length(path) div 2 + 1); // More realistic initial size for paths
+  if Length(path) = 0 then // Handle empty path case
+  begin
+    SetLength(list, 0);
+    Exit;
+  end;
+
+  k := 0;
+  oldPos := 1;
+  Repeat
+    // Use your WidePosExChar function here
+    newPos := WidePosExChar('\', path, oldPos);
+
+    if newPos = 0 then // No more delimiters found, this is the last segment
+    Begin
+      list[k] := Copy(path, oldPos, MaxInt); // Copy to the end of the string
+      Inc(k);
+      Break; // Exit the loop as we've processed the last segment
+    End
+    Else // Delimiter found
+    Begin
+      // Copy the segment from oldPos up to (but not including) the delimiter
+      list[k] := Copy(path, oldPos, newPos - oldPos);
+      Inc(k);
+      // Move oldPos to the character *after* the delimiter
+      oldPos := newPos + 1;
+    End;
+
+    // Check if oldPos has gone beyond the string length,
+    // which can happen if the path ends with a delimiter.
+    // If it does, and there's an empty segment at the end, add it.
+    if (oldPos > Length(path)) and (newPos <> 0) then // newPos=0 indicates last segment was handled
+    begin
+      // Add an empty string if the path ended with a backslash and we're at the end
+      if (path[Length(path)] = '\') then // Only if the original string ended with '\'
+      begin
+        list[k] := '';
+        Inc(k);
+      end;
+      Break;
+    end;
+
+  Until False; // Use Break to exit the loop once last segment is processed
+
+  SetLength(list, k); // Trim the list to the actual number of segments
 end;
 
 Procedure SaveRamDisk(Var existing:TRamDisk);

--- a/SrvMain.pas
+++ b/SrvMain.pas
@@ -151,7 +151,18 @@ procedure TArsenalRamDisk.ServiceStart(Sender: TService; var Started: Boolean);
 begin
   FShutdownThread := nil;
   DebugLog('RamDisk service was started');
+
+  // Report that we are starting, with a 60 second timeout
+  WaitHint := 60000;
+  CheckPoint := 1;
+  ReportStatus;
+
   LoadSettings;
+
+  // Report progress
+  CheckPoint := 2;
+  ReportStatus;
+
   if (config.size<>0) then
   try
     if CreateRamDisk(config,False) Then Started:=True;
@@ -159,11 +170,17 @@ begin
     On E:ERamDiskError do DebugLog(decodeException(E.ArsenalCode));
     On E:Exception do DebugLog(E.Message);
   End;
+
+  // Reset WaitHint
+  WaitHint := 0;
 end;
 
 procedure TArsenalRamDisk.ServiceStop(Sender: TService; var Stopped: Boolean);
 begin
   DebugLog('RamDisk service is being stopped');
+  // Report that we are stopping, with a 60 second timeout
+  WaitHint := 60000;
+  CheckPoint := 1;
   ReportStatus;
   try
     if config.letter <> #0 then
@@ -179,6 +196,8 @@ begin
   finally
     inherited;
   end;
+  // Reset WaitHint
+  WaitHint := 0;
 end;
 
 end.


### PR DESCRIPTION
I've decided to upload the broken code,

As far as I can tell the broken code is not really that big of an issue.

To fix it, it would probably require storing the ServiceHandle into the object.

h_sv<something> is created somewhere, can't remember clearly, maybe storing that in ServiceHandle member field could fix this code.

For now I ran out of steam trying to fix this.

But perhaps you will find this code interesting to see what it does... there are some other fixes in here too.. in create ram and such in case for whatever reason ram disk creation fails, I could imagine this might happen if out of memory or something...